### PR TITLE
[0252] Amended initialiser for semantic logger to be more relaxed

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,4 +1,4 @@
-if Rails.env.development? || Rails.env.production?
+unless Rails.env.test?
   Rails.application.configure do
     config.log_tags = [:request_id] # Prepend all log lines with the following tags
   end


### PR DESCRIPTION
### Context
Semantic logger

### Changes proposed in this pull request
Amended initialiser for semantic logger to be more relaxed.

Previously it was only enabled on development and production.

### Guidance to review
:ship: 

Bypassing test as it generates a lot of noise