### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Merge minor dependency updates
-        uses: fastify/github-action-merge-dependabot@v3
+        uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 #Pinned at v3.12.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor


### PR DESCRIPTION

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR