### PR TITLE
[xxxx] Update alpine image to fix build

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby      3.4.8
+ruby      3.4.9
 nodejs    24.13.0
 postgres  17.2
 terraform 1.14.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # production: runs the actual app
 
 # Build builder image
-FROM ruby:3.4.8-alpine3.22 AS builder
+FROM ruby:3.4.9-alpine3.22 AS builder
 
 WORKDIR /app
 
@@ -53,7 +53,7 @@ RUN rm -rf node_modules log/* tmp/* /tmp && \
     find /usr/local/bundle/gems -name "*.html" -delete
 
 # Build runtime image
-FROM ruby:3.4.8-alpine3.22 AS production
+FROM ruby:3.4.9-alpine3.22 AS production
 
 # The application runs from /app
 WORKDIR /app


### PR DESCRIPTION
### Context

ruby:3.4.8-alpine3.22 has vulnerabilities so changed to ruby:3.4.9-alpine3.22

See Synk output: https://github.com/DFE-Digital/register-placement-schools/actions/runs/25629098337/job/75229430683

### Changes proposed in this pull request

* Update alpine image but keep alpine version the same
* Minor bump to ruby

### Guidance to review

Does build work?