### PR TITLE
2813: Update postgres sku to v5 for prod

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -3,7 +3,7 @@
   "namespace": "bat-production",
   "web_replicas": 2,
   "azure_enable_high_availability": true,
-  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "enable_postgres_backup_storage": true,
   "azure_maintenance_window": {
     "day_of_week": 0,


### PR DESCRIPTION
### Context

Upgrade the following prod postgres servers to v5:

**s189p01-rops-pd-rg**

This will cause a 10-20 minute downtime.

- Tom Trentham has confirmed this can be run at 8am on Thursday 2nd July, with a maintenance page set.

### Changes proposed in this pull request

Replace v4 sku with the v5 version.

This will give a performance improvement without any price increase.

### Guidance to review

```
make production terraform-plan CONFIRM_PRODUCTION=yes
```

Due to changes in the postgres module we are alerted to the following:

```
module.postgres.azurerm_monitor_diagnostic_setting.main[0] will be updated in-place
```

_This should have no adverse effect during the apply stage of this Terraform code. The monitoring categories are moving to dynamic declaration and, regardless, they are not currently set with any values._

The below monitoring alert resources will also be amended:

```
module.postgres.azurerm_monitor_metric_alert.cpu[0] will be updated in-place
module.postgres.azurerm_monitor_metric_alert.memory[0] will be updated in-place
module.postgres.azurerm_monitor_metric_alert.storage[0] will be updated in-place
```

It appears that, for all the above, a webhook is being added:

```
- action {
          - action_group_id    = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-rops-mn-rg/providers/Microsoft.Insights/actionGroups/s189p01-register-placement-schools" -> null
          - webhook_properties = {} -> null
        }
      + action {
          + action_group_id    = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-rops-mn-rg/providers/Microsoft.Insights/actionGroups/s189p01-register-placement-schools"
          + webhook_properties = {
              + "environment"     = "production"
              + "target_channels" = "rops"
            }
        }
```

_Again, this is not a breaking change._

The only other change is that which is intended for the completion of this request:

```
# module.postgres.azurerm_postgresql_flexible_server.main[0] will be updated in-place
  ~ resource "azurerm_postgresql_flexible_server" "main" {
        id                                = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-rops-pd-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189p01-rops-pd-pg"
        name                              = "s189p01-rops-pd-pg"
      ~ sku_name                          = "GP_Standard_D2ds_v4" -> "GP_Standard_D2ds_v5"
        tags                              = {
            "Environment"      = "Prod"
            "Product"          = "Register of placement schools"
            "Service Offering" = null
        }
        # (21 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```

